### PR TITLE
バージョンアップ時にSqliteのマイグレーションを行う動作を追加

### DIFF
--- a/PeperomiaNative/package.json
+++ b/PeperomiaNative/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "^1.1.2",
     "@types/color": "^3.0.0",
+    "@types/compare-versions": "^3.0.0",
     "@types/expo": "^32.0.13",
     "@types/firebase": "^3.2.1",
     "@types/react": "^16.4.18",
@@ -35,6 +36,7 @@
     "@types/styled-components": "^4.1.18",
     "@types/uuid": "^3.4.4",
     "color": "^3.1.0",
+    "compare-versions": "^3.5.0",
     "expo": "^33.0.0",
     "expo-camera": "~5.0.1",
     "expo-constants": "~5.0.1",

--- a/PeperomiaNative/src/app.tsx
+++ b/PeperomiaNative/src/app.tsx
@@ -16,6 +16,7 @@ import { Provider as PaperProvider } from "react-native-paper";
 import ItemsProvider from "./containers/Items";
 import AuthProvider from "./containers/Auth";
 import FetchProvider from "./containers/Fetch";
+import Version from "./containers/Version";
 import Home from "./components/pages/Home/Connected";
 import Setting from "./components/pages/Setting/Connected";
 import CreatePlan from "./components/pages/CreatePlan/Connected";
@@ -34,6 +35,7 @@ import {
   User
 } from "./lib/db/user";
 import theme from "./config/theme";
+import app from "../app.json";
 
 Sentry.enableInExpoDevelopment = true;
 
@@ -217,6 +219,8 @@ export default class App extends Component<Props, State> {
       });
 
       AsyncStorage.setItem("userID", user.uuid);
+      // 現在のバージョンを設定
+      AsyncStorage.setItem("APP_VERSION", app.expo.version);
     } else {
       AsyncStorage.setItem("userID", data.uuid);
       this.setState({
@@ -254,13 +258,15 @@ export default class App extends Component<Props, State> {
     return (
       <PaperProvider>
         <ActionSheetProvider>
-          <AuthProvider>
-            <FetchProvider>
-              <ItemsProvider>
-                <AppContainer />
-              </ItemsProvider>
-            </FetchProvider>
-          </AuthProvider>
+          <Version>
+            <AuthProvider>
+              <FetchProvider>
+                <ItemsProvider>
+                  <AppContainer />
+                </ItemsProvider>
+              </FetchProvider>
+            </AuthProvider>
+          </Version>
         </ActionSheetProvider>
       </PaperProvider>
     );

--- a/PeperomiaNative/src/components/pages/Setting/Connected.tsx
+++ b/PeperomiaNative/src/components/pages/Setting/Connected.tsx
@@ -8,7 +8,13 @@ import {
 import { AsyncStorage, Alert } from "react-native";
 import theme from "../../../config/theme";
 import { db } from "../../../lib/db";
-import { deleteSql, resetSql, deleteUserSql } from "../../../lib/db/debug";
+import {
+  deleteSql,
+  resetSql,
+  resetSqlV100,
+  deleteUserSql,
+  sqliteMaster
+} from "../../../lib/db/debug";
 import { select as selectItems } from "../../../lib/db/item";
 import { select as selectItemDetailds } from "../../../lib/db/itemDetail";
 import { Consumer as AuthConsumer } from "../../../containers/Auth";
@@ -94,6 +100,7 @@ class Connected extends Component<ConnectedProps, State> {
     db.transaction((tx: SQLite.Transaction) => {
       selectItems(tx, console.log);
       selectItemDetailds(tx, console.log);
+      sqliteMaster(tx);
     });
   };
 
@@ -157,6 +164,14 @@ class Connected extends Component<ConnectedProps, State> {
     );
   };
 
+  onMigrationV100 = () => {
+    db.transaction((tx: SQLite.Transaction) => {
+      resetSqlV100(tx);
+    });
+
+    AsyncStorage.setItem("APP_VERSION", "1.0.0");
+  };
+
   render() {
     return (
       <Page
@@ -173,6 +188,7 @@ class Connected extends Component<ConnectedProps, State> {
         onSignIn={this.onSignIn}
         onLogout={this.onLogout}
         onMyPage={this.onMyPage}
+        onMigrationV100={this.onMigrationV100}
       />
     );
   }

--- a/PeperomiaNative/src/components/pages/Setting/Page.tsx
+++ b/PeperomiaNative/src/components/pages/Setting/Page.tsx
@@ -25,6 +25,7 @@ export interface Props {
   onLogout: () => void;
   onFeedback: () => void;
   onMyPage: () => void;
+  onMigrationV100: () => void;
 }
 
 export default class extends Component<Props> {
@@ -126,6 +127,11 @@ export default class extends Component<Props> {
               <List.Item
                 title="ユーザー初期化"
                 onPress={this.props.onDeleteUser}
+              />
+              <Divider />
+              <List.Item
+                title="v1,0.0の状態にする"
+                onPress={this.props.onMigrationV100}
               />
               <Divider />
               <List.Item

--- a/PeperomiaNative/src/containers/Version.tsx
+++ b/PeperomiaNative/src/containers/Version.tsx
@@ -1,0 +1,44 @@
+import { Component } from "react";
+import { AsyncStorage } from "react-native";
+import compareVersions from "compare-versions";
+import { migrationV104 } from "../lib/migration";
+
+interface Props {}
+
+interface State {
+  loading: boolean;
+}
+
+export default class extends Component<Props, State> {
+  state = {
+    loading: true
+  };
+
+  async componentDidMount() {
+    let appVerion = await AsyncStorage.getItem("APP_VERSION");
+    if (!appVerion) {
+      appVerion = "1.0.0";
+    }
+
+    if (compareVersions.compare("1.0.4", appVerion, ">")) {
+      // カラム追加のマイグレーション実行
+      const ok = await migrationV104();
+      if (ok) {
+        // 現在のバージョンを設定
+        AsyncStorage.setItem("APP_VERSION", "1.0.4");
+      }
+    }
+
+    this.setState({
+      loading: false
+    });
+  }
+
+  render() {
+    if (this.state.loading) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}

--- a/PeperomiaNative/src/lib/db/debug.ts
+++ b/PeperomiaNative/src/lib/db/debug.ts
@@ -19,6 +19,7 @@ import {
   KIND_CHERRY_BLOSSOM,
   KIND_SHIP
 } from "../getKind";
+import { success, error } from "./";
 
 export const deleteSql = (tx: SQLite.Transaction) => {
   tx.executeSql("drop table items");
@@ -226,4 +227,45 @@ export const resetSql = (tx: SQLite.Transaction) => {
 
   items.map(item => insertItem(tx, item));
   itemDetails.map(itemDetail => insertItemDetail(tx, itemDetail));
+};
+
+export const resetSqlV100 = (tx: SQLite.Transaction) => {
+  tx.executeSql("drop table items");
+  tx.executeSql("drop table item_details");
+
+  createItem(tx);
+  createItemDetailV100(tx);
+};
+
+export const createItemDetailV100 = async (
+  tx: SQLite.Transaction,
+  callback?: (data: any, error: any) => void
+) => {
+  return tx.executeSql(
+    "create table if not exists item_details (" +
+      "id integer primary key not null," +
+      "itemId integer," +
+      "title string," +
+      "kind string," +
+      "memo string," +
+      "moveMinutes integer," +
+      "priority integer" +
+      ");",
+    [],
+    (_: any, props: any) => success(props.rows._array, callback),
+    (_: any, err: any) => error(err, callback)
+  );
+};
+
+export const sqliteMaster = async (tx: SQLite.Transaction) => {
+  return tx.executeSql(
+    "select * from sqlite_master;",
+    [],
+    (_: any, props: any) => {
+      console.log(props.rows._array);
+    },
+    (_: any, err: any) => {
+      console.log(err);
+    }
+  );
 };

--- a/PeperomiaNative/src/lib/db/index.ts
+++ b/PeperomiaNative/src/lib/db/index.ts
@@ -3,7 +3,7 @@ import { create as createItem } from "./item";
 import { create as createItemDetail } from "./itemDetail";
 import { create as createUser } from "./user";
 
-export const db = SQLite.openDatabase("db.db");
+export const db: any = SQLite.openDatabase("db.db");
 
 export const success = (
   data: any,

--- a/PeperomiaNative/src/lib/db/migration.ts
+++ b/PeperomiaNative/src/lib/db/migration.ts
@@ -1,0 +1,34 @@
+import { SQLite } from "expo-sqlite";
+import { success, error } from "./";
+
+export const migrationV1040 = async (
+  tx: SQLite.Transaction,
+  callback?: (error: any) => void
+) => {
+  const query = `alter table item_details add column place string;`;
+
+  return tx.executeSql(
+    query,
+    [],
+    (_: any, props: any) => success(props, callback),
+    (_: any, err: any) => {
+      error(err, callback);
+    }
+  );
+};
+
+export const migrationV1041 = async (
+  tx: SQLite.Transaction,
+  callback?: (error: any) => void
+) => {
+  const query = `alter table item_details add column url string;`;
+
+  return tx.executeSql(
+    query,
+    [],
+    (_: any, props: any) => success(props, callback),
+    (_: any, err: any) => {
+      error(err, callback);
+    }
+  );
+};

--- a/PeperomiaNative/src/lib/migration.ts
+++ b/PeperomiaNative/src/lib/migration.ts
@@ -1,0 +1,21 @@
+import { SQLite } from "expo-sqlite";
+import { Sentry } from "react-native-sentry";
+import {
+  migrationV1040 as v1040,
+  migrationV1041 as v1041
+} from "./db/migration";
+import { db } from "./db";
+
+export const migrationV104 = async (): Promise<Boolean> => {
+  try {
+    await db.transaction(async (tx: SQLite.Transaction) => {
+      await v1040(tx);
+      await v1041(tx);
+    });
+
+    return true;
+  } catch (err) {
+    Sentry.captureMessage(err);
+    return false;
+  }
+};

--- a/PeperomiaNative/tsconfig.json
+++ b/PeperomiaNative/tsconfig.json
@@ -15,7 +15,8 @@
     ],
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
-    "strict": true
+    "strict": true,
+    "resolveJsonModule": true
   },
   "include": [
     "src"

--- a/PeperomiaNative/yarn.lock
+++ b/PeperomiaNative/yarn.lock
@@ -2428,6 +2428,11 @@
   dependencies:
     "@types/color-convert" "*"
 
+"@types/compare-versions@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/compare-versions/-/compare-versions-3.0.0.tgz#4a45dffe0ebbc00d0f2daef8a0e96ffc66cf5955"
+  integrity sha512-HNXtUQQuW3ThO9DVfTNbdvClVr+8AZlNNa2pxk5qtEvObnT27qh0DdQXTN4h5PuTTGinxwXkRKXsllJxuAzGPw==
+
 "@types/detox@^12.8.2":
   version "12.8.2"
   resolved "https://registry.yarnpkg.com/@types/detox/-/detox-12.8.2.tgz#b206fee84d6d225bb8913308170d58e40edb7e6a"
@@ -4477,7 +4482,7 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
 
-compare-versions@^3.4.0:
+compare-versions@^3.4.0, compare-versions@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.5.0.tgz#85fc22a1ae9612ff730d77fb092295acd056d311"
 


### PR DESCRIPTION
## 関連 issue
 -  fixes #31 

## 対応内容
 - アプリのストレージに使用中のアプリバージョンを保持
 - 保持したバージョンと現在の使用しているアプリのバージョンに差異がある場合は内部のSqliteのマイグレーションを行う