### PR TITLE
スケジュール画面とスケジュール詳細画面にローディングを実装

### DIFF
--- a/PeperomiaNative/src/components/organisms/Schedule/Cards.tsx
+++ b/PeperomiaNative/src/components/organisms/Schedule/Cards.tsx
@@ -4,9 +4,11 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { SelectItemDetail } from '../../../domain/itemDetail';
 import Card from '../../molecules/Schedule/TouchableCard';
 import { ConnectedType } from '../../pages/Schedule/Connected';
+import Loading from './Loading';
 
 type Props = Pick<ConnectedType, 'onScheduleDetail'> & {
   data: SelectItemDetail[];
+  loading: boolean;
 };
 
 export default class extends Component<Props> {
@@ -22,6 +24,10 @@ export default class extends Component<Props> {
   }
 
   render() {
+    if (this.props.loading) {
+      return <Loading />;
+    }
+
     return (
       <FlatList
         data={this.props.data}

--- a/PeperomiaNative/src/components/organisms/Schedule/Loading.tsx
+++ b/PeperomiaNative/src/components/organisms/Schedule/Loading.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { View, Dimensions } from 'react-native';
 import SvgAnimatedLinearGradient from 'react-native-svg-animated-linear-gradient';
 import EStyleSheet from 'react-native-extended-stylesheet';
-import { Circle, Rect } from 'react-native-svg';
+import { Rect } from 'react-native-svg';
 import theme from '../../../config/theme';
 
 const deviceWidth = Dimensions.get('window').width;
@@ -13,40 +13,40 @@ const Header: FC<Props> = () => {
   return (
     <View style={styles.root}>
       <SvgAnimatedLinearGradient
-        height={231}
+        height={116}
         width={deviceWidth}
         primaryColor={theme().mode.loading.primaryColor}
         secondaryColor={theme().mode.loading.secondaryColor}
       >
-        <Rect x="0" y="0" rx="0" ry="0" width={deviceWidth} height="231" />
+        <Rect x="0" y="0" rx="0" ry="0" width={deviceWidth} height="68" />
+        <Rect x="15" y="86" rx="10" ry="10" width={10} height="5" />
       </SvgAnimatedLinearGradient>
       <SvgAnimatedLinearGradient
-        height={60}
+        height={116}
         width={deviceWidth}
         primaryColor={theme().mode.loading.primaryColor}
         secondaryColor={theme().mode.loading.secondaryColor}
       >
-        <Circle cx="30" cy="30" r="10" />
-        <Rect x="60" y="20" rx="0" ry="0" width="40" height="20" />
-        <Rect x="0" y="58" rx="0" ry="0" width={deviceWidth} height="2" />
+        <Rect x="0" y="0" rx="0" ry="0" width={deviceWidth} height="68" />
+        <Rect x="15" y="86" rx="10" ry="10" width={10} height="5" />
       </SvgAnimatedLinearGradient>
       <SvgAnimatedLinearGradient
-        height={100}
+        height={116}
         width={deviceWidth}
         primaryColor={theme().mode.loading.primaryColor}
         secondaryColor={theme().mode.loading.secondaryColor}
       >
-        <Rect x="18" y="18" rx="10" ry="10" width="85" height="28" />
-        <Rect x="20" y="55" rx="0" ry="0" width="210" height="18" />
+        <Rect x="0" y="0" rx="0" ry="0" width={deviceWidth} height="68" />
+        <Rect x="15" y="86" rx="10" ry="10" width={10} height="5" />
       </SvgAnimatedLinearGradient>
       <SvgAnimatedLinearGradient
-        height={100}
+        height={116}
         width={deviceWidth}
         primaryColor={theme().mode.loading.primaryColor}
         secondaryColor={theme().mode.loading.secondaryColor}
       >
-        <Rect x="18" y="18" rx="10" ry="10" width="85" height="28" />
-        <Rect x="20" y="55" rx="0" ry="0" width="210" height="18" />
+        <Rect x="0" y="0" rx="0" ry="0" width={deviceWidth} height="68" />
+        <Rect x="15" y="86" rx="10" ry="10" width={10} height="5" />
       </SvgAnimatedLinearGradient>
     </View>
   );

--- a/PeperomiaNative/src/components/organisms/Schedule/stories.js
+++ b/PeperomiaNative/src/components/organisms/Schedule/stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from "@storybook/react-native";
 import { View } from "react-native";
 import { KIND_PARK } from "../../../lib/getKind";
 import Cards from "./Cards";
+import Loading from './Loading';
 
 const props = [
   {
@@ -30,8 +31,15 @@ const props = [
   }
 ];
 
-storiesOf("organisms/Schedule", module).add("Cards", () => (
-  <View style={{ paddingTop: 60 }}>
-    <Cards data={props} />
-  </View>
-));
+storiesOf('organisms/Schedule/Cards', module)
+  .add('カード一覧', () => (
+    <View style={{ paddingTop: 60 }}>
+      <Cards data={props} />
+    </View>
+  ))
+  .add('ローディング', () => (
+    <View style={{ paddingTop: 60 }}>
+      <Loading />
+    </View>
+  ));
+

--- a/PeperomiaNative/src/components/pages/Schedule/Connected.tsx
+++ b/PeperomiaNative/src/components/pages/Schedule/Connected.tsx
@@ -26,6 +26,7 @@ type Props = Pick<SwitchType, 'onAdd' | 'onSort' | 'onDelete'> & {
 type State = {
   itemDetails: SelectItemDetail[];
   refresh: string;
+  loading: boolean;
 };
 
 export type ConnectedType = {
@@ -33,7 +34,11 @@ export type ConnectedType = {
 };
 
 export default memo((props: Props) => {
-  const [state, setState] = useState<State>({ itemDetails: [], refresh: '' });
+  const [state, setState] = useState<State>({
+    itemDetails: [],
+    refresh: '',
+    loading: true,
+  });
   const navigation = useContext(NavigationContext);
   const { uid } = useContext(AuthContext);
   const { navigate } = useNavigation();
@@ -83,6 +88,7 @@ export default memo((props: Props) => {
       setState(s => ({
         ...s,
         itemDetails: itemDetails,
+        loading: false,
       }));
     },
     [navigation, props.navigation, uid]
@@ -132,6 +138,7 @@ export default memo((props: Props) => {
 
   return (
     <Page
+      loading={state.loading}
       data={state.itemDetails}
       onScheduleDetail={onScheduleDetail}
       onAdd={() => props.onAdd(state.itemDetails)}

--- a/PeperomiaNative/src/components/pages/Schedule/Page.tsx
+++ b/PeperomiaNative/src/components/pages/Schedule/Page.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { FC, memo, useCallback } from 'react';
 import { View, Alert } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { SelectItemDetail } from '../../../domain/itemDetail';
@@ -8,13 +8,14 @@ import { ConnectedType } from './Connected';
 
 type Props = Pick<ConnectedType, 'onScheduleDetail'> & {
   data: SelectItemDetail[];
+  loading: boolean;
   onAdd: () => void;
   onSort: () => void;
   onDelete: () => void;
 };
 
-export default class extends Component<Props> {
-  onDelete = () => {
+const SchedulePage: FC<Props> = memo(props => {
+  const onDelete = useCallback(() => {
     Alert.alert(
       '本当に削除しますか？',
       '',
@@ -26,32 +27,33 @@ export default class extends Component<Props> {
         {
           text: '削除する',
           onPress: () => {
-            this.props.onDelete();
+            props.onDelete();
           },
         },
       ],
       { cancelable: false }
     );
-  };
+  }, [props]);
 
-  render() {
-    return (
-      <View style={styles.root}>
-        <Cards
-          data={this.props.data}
-          onScheduleDetail={this.props.onScheduleDetail}
+  return (
+    <View style={styles.root}>
+      <Cards
+        data={props.data}
+        onScheduleDetail={props.onScheduleDetail}
+        loading={props.loading}
+      />
+      <View style={styles.footer}>
+        <ActionButton
+          onAdd={props.onAdd}
+          onSort={props.onSort}
+          onDelete={onDelete}
         />
-        <View style={styles.footer}>
-          <ActionButton
-            onAdd={this.props.onAdd}
-            onSort={this.props.onSort}
-            onDelete={this.onDelete}
-          />
-        </View>
       </View>
-    );
-  }
-}
+    </View>
+  );
+});
+
+export default SchedulePage;
 
 const styles = EStyleSheet.create({
   root: {

--- a/PeperomiaNative/src/components/pages/Schedule/stories.js
+++ b/PeperomiaNative/src/components/pages/Schedule/stories.js
@@ -31,8 +31,15 @@ const data = [
   }
 ];
 
-storiesOf("pages", module).add("Schedule", () => (
-  <View style={{ paddingTop: 60 }}>
-    <Page data={data} />
-  </View>
-));
+storiesOf('pages/Schedule', module)
+  .add('画面', () => (
+    <View style={{ paddingTop: 60 }}>
+      <Page data={data} />
+    </View>
+  ))
+  .add('ローディング', () => (
+    <View style={{ paddingTop: 60 }}>
+      <Page data={data} loading/>
+    </View>
+  ));
+

--- a/PeperomiaNative/src/config/theme.ts
+++ b/PeperomiaNative/src/config/theme.ts
@@ -121,8 +121,8 @@ const theme: Theme = {
         text: baseColor.lightGreen,
       },
       loading: {
-        primaryColor: '#eee',
-        secondaryColor: '#ddd',
+        primaryColor: '#ccc',
+        secondaryColor: '#bbb',
       },
     },
   },


### PR DESCRIPTION
## 関連 issue
 -  fixes #403 

## 対応内容

- API経由で読み込みを行うと表示にラグが合ったためローディングを実装

<div style="dispplay:flex">
<img src="https://user-images.githubusercontent.com/19209314/73657680-20797d80-46d6-11ea-9eb0-74a14fe16f59.gif" height="500">
<img src="https://user-images.githubusercontent.com/19209314/73657685-25d6c800-46d6-11ea-944f-d6924c1b6c3a.gif" height="500">
</div>
