### PR TITLE
 スケジュールの順番変更の処理で無駄にAPI更新の処理が走っている不具合の修正

### DIFF
--- a/PeperomiaNative/src/components/pages/CreateSchedule/Connected.tsx
+++ b/PeperomiaNative/src/components/pages/CreateSchedule/Connected.tsx
@@ -50,6 +50,8 @@ export default memo((props: Props) => {
           ...s,
           itemDetails: data,
         }));
+
+        return;
       }
 
       // priorityが重複している場合はid順でpriorityをupdateする

--- a/PeperomiaNative/src/components/pages/Schedule/Connected.tsx
+++ b/PeperomiaNative/src/components/pages/Schedule/Connected.tsx
@@ -21,6 +21,7 @@ import Page from './Page';
 
 type Props = Pick<SwitchType, 'onAdd' | 'onSort' | 'onDelete'> & {
   navigation: NavigationScreenProp<NavigationRoute>;
+  itemDetails: SelectItemDetail[];
 };
 
 type State = {
@@ -55,10 +56,14 @@ export default memo((props: Props) => {
         navigation.setParams({
           itemDetails: data,
         });
+
         setState(s => ({
           ...s,
           itemDetails: data,
+          loading: false,
         }));
+
+        return;
       }
 
       // priorityが重複している場合はid順でpriorityをupdateする
@@ -105,7 +110,11 @@ export default memo((props: Props) => {
 
   useDidMount(() => {
     const itemId = props.navigation.getParam('itemId', '1');
-    getData(String(itemId));
+    if (props.itemDetails.length > 0) {
+      setitemDetails(props.itemDetails);
+    } else {
+      getData(String(itemId));
+    }
   });
 
   useEffect(() => {
@@ -142,7 +151,7 @@ export default memo((props: Props) => {
       data={state.itemDetails}
       onScheduleDetail={onScheduleDetail}
       onAdd={() => props.onAdd(state.itemDetails)}
-      onSort={() => props.onSort(state.itemDetails)}
+      onSort={() => props.onSort()}
       onDelete={props.onDelete}
     />
   );


### PR DESCRIPTION
## 関連 issue
 -  fixes #420

## 対応内容

 - スケジュールの順番変更の処理で無駄にAPI更新の処理が走っている不具合があったので修正

## 開発用メモ
不具合時のスクリーンショット（1回の変更に4回APIアクセスが走っている）
<img width="886" alt="スクリーンショット 2020-02-07 00 57 16" src="https://user-images.githubusercontent.com/19209314/73954660-7b64dc00-4945-11ea-83d1-8f277fd2f6c2.png">
