### PR TITLE
デバッグモードにSQLlite使用とFirestore使用の切り替えトグルを追加

### DIFF
--- a/PeperomiaNative/src/app.tsx
+++ b/PeperomiaNative/src/app.tsx
@@ -27,6 +27,7 @@ import CreateScheduleDetail from "./components/pages/CreateScheduleDetail/Connec
 import Icons from "./components/pages/Icons/Connected";
 import AppInfo from "./components/pages/AppInfo/Page";
 import { db, init} from "./lib/db";
+import { setDebugMode } from "./lib/auth";
 import "./lib/firebase";
 import {
   select1st as selectUser1st,
@@ -225,11 +226,16 @@ export default class App extends Component<Props, State> {
     loading: true
   };
 
-  componentDidMount() {
+  async componentDidMount() {
     db.transaction((tx: SQLite.SQLTransaction) => {
       init(tx);
       selectUser1st(tx, this.checkUser);
     });
+    
+    if (!Constants.isDevice) {
+      const debugMode = await AsyncStorage.getItem('DEBUG_MODE');
+      await setDebugMode(Boolean(debugMode))
+    }
   }
 
   checkUser = (data: User | null, error: SQLite.SQLError | null) => {

--- a/PeperomiaNative/src/components/pages/Setting/Connected.tsx
+++ b/PeperomiaNative/src/components/pages/Setting/Connected.tsx
@@ -26,6 +26,7 @@ import { useDidMount } from '../../../hooks/index';
 import { getFireStore } from '../../../lib/firebase';
 import { resetQuery } from '../../../lib/firestore/debug';
 import { findByUID } from '../../../lib/firestore/item';
+import { setDebugMode, getDebugMode } from '../../../lib/auth';
 import Tos from '../Tos/Page';
 import Policy from '../Policy/Page';
 import Feedback from '../Feedback/Connected';
@@ -61,6 +62,7 @@ type ConnectedProps = Pick<FetchContextProps, 'post'> &
 type State = {
   login: boolean;
   loading: boolean;
+  debugMode: boolean;
 };
 
 const Connected = memo((props: ConnectedProps) => {
@@ -68,6 +70,7 @@ const Connected = memo((props: ConnectedProps) => {
   const [state, setState] = useState<State>({
     loading: true,
     login: false,
+    debugMode: false,
   });
 
   useDidMount(() => {
@@ -75,11 +78,17 @@ const Connected = memo((props: ConnectedProps) => {
       if (props.loggedIn) {
         const loggedIn = await props.loggedIn();
 
-        setState({
+        setState(s => ({
+          ...s,
           login: loggedIn,
           loading: false,
-        });
+        }));
       }
+      const debugMode = await getDebugMode();
+      setState(s => ({
+        ...s,
+        debugMode,
+      }));
     };
 
     check();
@@ -130,10 +139,11 @@ const Connected = memo((props: ConnectedProps) => {
   const onSignIn = useCallback(() => {
     navigate('SignIn', {
       onLogin: () => {
-        setState({
+        setState(s => ({
+          ...s,
           login: true,
           loading: false,
-        });
+        }));
       },
     });
   }, [navigate]);
@@ -206,10 +216,19 @@ const Connected = memo((props: ConnectedProps) => {
     console.log(r);
   }, [props.uid]);
 
+  const onChangeDebugMode = useCallback(async (val: boolean) => {
+    await setDebugMode(val);
+    setState(s => ({
+      ...s,
+      debugMode: val,
+    }));
+  }, []);
+
   return (
     <Page
       loading={state.loading}
       login={state.login}
+      debugMode={state.debugMode}
       onResetSQL={onResetSQL}
       onData={onData}
       onDeleteSQL={onDeleteSQL}
@@ -226,6 +245,7 @@ const Connected = memo((props: ConnectedProps) => {
       onLoginWithAmazon={onLoginWithAmazon}
       onFirestoreResetQuery={onFirestoreResetQuery}
       onFirestoreSelect={onFirestoreSelect}
+      onChangeDebugMode={onChangeDebugMode}
     />
   );
 });

--- a/PeperomiaNative/src/components/pages/Setting/Page.tsx
+++ b/PeperomiaNative/src/components/pages/Setting/Page.tsx
@@ -16,6 +16,7 @@ import app from '../../../../app.json';
 type Props = {
   login: boolean;
   loading: boolean;
+  debugMode: boolean;
   onResetSQL: () => void;
   onDeleteSQL: () => void;
   onShowSQL: () => void;
@@ -32,6 +33,7 @@ type Props = {
   onLoginWithAmazon: () => void;
   onFirestoreResetQuery: () => void;
   onFirestoreSelect: () => void;
+  onChangeDebugMode: (val: boolean) => void;
 };
 
 const SettingPage: FC<Props> = props => (
@@ -178,6 +180,15 @@ const SettingPage: FC<Props> = props => (
             }}
           />
           <Divider />
+          <ListItem
+            title="使用DBをSQLiteにする"
+            switch={{
+              value: props.debugMode,
+              onValueChange: props.onChangeDebugMode,
+            }}
+            bottomDivider
+          />
+
           <ListItem
             title="アプリを再起動する"
             onPress={() => {

--- a/PeperomiaNative/src/containers/Auth.tsx
+++ b/PeperomiaNative/src/containers/Auth.tsx
@@ -75,12 +75,7 @@ const Auth: FC<Props> = memo(props => {
     }
 
     const expiration = await AsyncStorage.getItem('expiration');
-    /*
-    console.log(expiration);
-    console.log(dayjs(new Date(Number(expiration) * 1000)).format());
-    console.log(dayjs().format());
-    console.log(dayjs(new Date(Number(expiration) * 1000)).isAfter(dayjs()));
-    */
+
     if (dayjs(new Date(Number(expiration) * 1000)).isAfter(dayjs())) {
       return idToken;
     }

--- a/PeperomiaNative/src/lib/auth.ts
+++ b/PeperomiaNative/src/lib/auth.ts
@@ -2,6 +2,22 @@ import * as firebase from 'firebase';
 import { AsyncStorage } from 'react-native';
 import { UID } from '../domain/user';
 
+var isDebugMode: boolean = false;
+
+export const setDebugMode = async (debugMode: boolean) => {
+  if (debugMode) {
+    await AsyncStorage.setItem('DEBUG_MODE', 'true');
+  } else {
+    await AsyncStorage.removeItem('DEBUG_MODE');
+  }
+
+  isDebugMode = debugMode;
+};
+
+export const getDebugMode = () => {
+  return isDebugMode;
+};
+
 const setSession = async (refresh = false) => {
   const user = firebase.auth().currentUser;
   if (!user) {
@@ -33,6 +49,11 @@ export const getIdToken = async () => {
 };
 
 export const isLogin = (uid: UID): boolean => {
+  if (isDebugMode) {
+    // デバッグモード:ONの場合は強制的にSQLiteの値を見る
+    return false;
+  }
+
   if (uid) {
     return true;
   }


### PR DESCRIPTION
## 関連 issue
 -  fixes #423

## 対応内容

 - ローカルデバッグ用にログイン後もSQLliteを使用できるデバッグ機能を追加
 - デバッグ機能のトグルからON/OFF可能

<div style="display:flex">
<img src="https://user-images.githubusercontent.com/19209314/74097920-55158b00-4b55-11ea-8863-b5843bc4eedb.png" width="200">
<img src="https://user-images.githubusercontent.com/19209314/74097921-5941a880-4b55-11ea-8437-f24c153d0409.png" width="200">
</div>

