### PR TITLE
react-navigation v5でダークモード対応

### DIFF
--- a/PeperomiaNative/appBase.jq
+++ b/PeperomiaNative/appBase.jq
@@ -21,7 +21,9 @@
       "fallbackToCacheTimeout": 0
     },
     "assetBundlePatterns": ["src/**/*"],
+    "userInterfaceStyle": "automatic",
     "ios": {
+      "userInterfaceStyle": "automatic",
       "usesAppleSignIn": true,
       "supportsTablet": true,
       "buildNumber": "16",
@@ -38,6 +40,7 @@
       }
     },
     "android": {
+      "userInterfaceStyle": "automatic",
       "package": "com.wheatandcat.peperomia",
       "googleServicesFile": "./android/google-services.json",
       "versionCode": 16,

--- a/PeperomiaNative/src/components/pages/Home/Connected.tsx
+++ b/PeperomiaNative/src/components/pages/Home/Connected.tsx
@@ -12,7 +12,6 @@ import theme, { darkMode } from 'config/theme';
 import { deleteItem } from 'lib/item';
 import { RootStackParamList } from 'lib/navigation';
 import { useItems, ContextProps as ItemContextProps } from 'containers/Items';
-import { useTheme, ContextProps as ThemeContextProps } from 'containers/Theme';
 import { useAuth } from 'containers/Auth';
 import { SelectItem } from 'domain/item';
 import { useDidMount } from 'hooks/index';
@@ -26,11 +25,10 @@ const deviceWidth = Dimensions.get('window').width;
 export type PlanProps = Pick<
   ItemContextProps,
   'items' | 'about' | 'refreshData'
-> &
-  Pick<ThemeContextProps, 'rerendering' | 'onFinishRerendering'> & {
-    loading: boolean;
-    refresh: string;
-  };
+> & {
+  loading: boolean;
+  refresh: string;
+};
 
 type PlanState = {
   refresh: string;
@@ -60,7 +58,6 @@ type Props = {
 
 const HomeScreen = ({ navigation, route }: Props) => {
   const { items, about, refreshData, itemsLoading } = useItems();
-  const { rerendering, onFinishRerendering } = useTheme();
   const [state, setState] = useState<HomeScreeState>({ mask: false });
 
   const refresh = route?.params?.refresh || '';
@@ -87,12 +84,10 @@ const HomeScreen = ({ navigation, route }: Props) => {
     <View>
       <HomeScreenPlan
         loading={Boolean(itemsLoading)}
-        rerendering={rerendering}
         items={items}
         about={about}
         refresh={String(refresh)}
         refreshData={refreshData}
-        onFinishRerendering={onFinishRerendering}
       />
       {state.mask && <View style={styles.mask} />}
     </View>
@@ -113,13 +108,6 @@ const HomeScreenPlan = memo((props: PlanProps) => {
   const { navigate } = useNavigation();
   const { uid } = useAuth();
   const [state, setState] = useState<PlanState>({ refresh: '' });
-
-  useDidMount(() => {
-    if (props.rerendering) {
-      navigate('ScreenSetting');
-      if (props.onFinishRerendering) props.onFinishRerendering();
-    }
-  });
 
   useEffect(() => {
     if (state.refresh === props.refresh) {

--- a/PeperomiaNative/src/components/pages/Setting/Connected.tsx
+++ b/PeperomiaNative/src/components/pages/Setting/Connected.tsx
@@ -14,7 +14,6 @@ import {
 } from 'lib/db/debug';
 import { select as selectItems } from 'lib/db/item';
 import { select as selectItemDetailds } from 'lib/db/itemDetail';
-import { useTheme } from 'containers/Theme';
 import { useAuth, ContextProps as AuthContextProps } from 'containers/Auth';
 import { useFetch, ContextProps as FetchContextProps } from 'containers/Fetch';
 import { useItems, ContextProps as ItemsContextProps } from 'containers/Items';
@@ -83,7 +82,6 @@ type State = {
 
 const Connected = memo((props: ConnectedProps) => {
   const { navigate } = useNavigation();
-  const { rerendering, onFinishRerendering } = useTheme();
   const [state, setState] = useState<State>({
     loading: true,
     login: false,
@@ -92,11 +90,6 @@ const Connected = memo((props: ConnectedProps) => {
   });
 
   useDidMount(() => {
-    if (rerendering) {
-      navigate('ScreenSetting');
-      if (onFinishRerendering) onFinishRerendering();
-    }
-
     const check = async () => {
       if (props.loggedIn) {
         const loggedIn = await props.loggedIn();

--- a/PeperomiaNative/src/components/pages/Setting/Page.tsx
+++ b/PeperomiaNative/src/components/pages/Setting/Page.tsx
@@ -33,13 +33,6 @@ const SettingPage: FC<Props> = (props) => (
         bottomDivider
         onPress={props.onFeedback}
       />
-      <ListItem
-        title="画面表示"
-        rightIcon={{ name: 'chevron-right', color: theme().mode.text }}
-        containerStyle={styles.menu}
-        titleStyle={styles.menuText}
-        onPress={props.onScreenSetting}
-      />
       <View style={styles.menuSpace} />
       <ListItem
         title="利用規約"
@@ -137,6 +130,13 @@ const SettingPage: FC<Props> = (props) => (
           <Text style={styles.debug}>デバッグ機能</Text>
           <Divider />
           <ListItem title={`UID: ${props.uid || ''}`} />
+          <ListItem
+            title="画面表示"
+            rightIcon={{ name: 'chevron-right', color: theme().mode.text }}
+            containerStyle={styles.menu}
+            titleStyle={styles.menuText}
+            onPress={props.onScreenSetting}
+          />
           <Divider />
           <ListItem title="初期データ投入" onPress={props.onResetSQL} />
           <Divider />
@@ -203,6 +203,7 @@ const styles = EStyleSheet.create({
   },
   menuSpace: {
     height: 20,
+    backgroundColor: '$settingRoot',
   },
   loginMenu: {
     height: 60,

--- a/PeperomiaNative/src/config/theme.ts
+++ b/PeperomiaNative/src/config/theme.ts
@@ -180,7 +180,7 @@ const theme: Theme = {
   },
 };
 
-let mode: ColorSchemeName = Appearance.getColorScheme();
+let mode: ColorSchemeName = Appearance.getColorScheme() || 'light';
 
 export const setMode = (modeType: ColorSchemeName) => {
   mode = modeType;

--- a/PeperomiaNative/src/config/theme.ts
+++ b/PeperomiaNative/src/config/theme.ts
@@ -1,4 +1,6 @@
 import EStyleSheet from 'react-native-extended-stylesheet';
+import { DefaultTheme, DarkTheme } from '@react-navigation/native';
+import { Appearance, ColorSchemeName } from 'react-native-appearance';
 
 type ThemeColor = {
   color: {
@@ -24,6 +26,7 @@ type ThemeColor = {
     sky: string;
     yellow: string;
     black: string;
+    pitchBlack: string;
   };
   mode: {
     background: string;
@@ -50,6 +53,7 @@ type ThemeColor = {
 type Theme = {
   light: ThemeColor;
   dark: ThemeColor;
+  'no-preference': ThemeColor;
 };
 
 const baseColor = {
@@ -75,6 +79,7 @@ const baseColor = {
   sky: '#00C2ED',
   yellow: '#f8e58c',
   black: '#333631',
+  pitchBlack: '#000',
 };
 
 const darkColor = {
@@ -100,6 +105,7 @@ const darkColor = {
   sky: '#00C2ED',
   yellow: '#f8e58c',
   black: '#333631',
+  pitchBlack: '#000',
 };
 
 const theme: Theme = {
@@ -129,18 +135,18 @@ const theme: Theme = {
   dark: {
     color: darkColor,
     mode: {
-      background: baseColor.black,
+      background: baseColor.pitchBlack,
       secondaryBackground: baseColor.darkGray,
       icon: baseColor.lightGray,
       text: baseColor.lightGray,
       secondaryText: baseColor.gray,
       tabBar: {
-        background: baseColor.darkGray,
-        activeTint: baseColor.lightGreen,
-        inactiveTint: baseColor.lightGray,
+        background: baseColor.pitchBlack,
+        activeTint: baseColor.highLightGray,
+        inactiveTint: baseColor.gray,
       },
       header: {
-        backgroundColor: baseColor.black,
+        backgroundColor: baseColor.pitchBlack,
         text: baseColor.highLightGray,
       },
       loading: {
@@ -149,11 +155,34 @@ const theme: Theme = {
       },
     },
   },
+  'no-preference': {
+    color: baseColor,
+    mode: {
+      background: baseColor.highLightGray,
+      secondaryBackground: baseColor.lightGray,
+      icon: baseColor.black,
+      text: baseColor.black,
+      secondaryText: baseColor.darkGray,
+      tabBar: {
+        background: baseColor.highLightGray,
+        activeTint: baseColor.main,
+        inactiveTint: baseColor.darkGray,
+      },
+      header: {
+        backgroundColor: baseColor.main,
+        text: baseColor.lightGreen,
+      },
+      loading: {
+        primaryColor: '#ccc',
+        secondaryColor: '#bbb',
+      },
+    },
+  },
 };
 
-let mode: 'light' | 'dark' = 'light';
+let mode: ColorSchemeName = Appearance.getColorScheme();
 
-export const setMode = (modeType: 'light' | 'dark') => {
+export const setMode = (modeType: ColorSchemeName) => {
   mode = modeType;
 
   const themeMode = theme[mode].mode;
@@ -169,13 +198,15 @@ export const setMode = (modeType: 'light' | 'dark') => {
     $searchInputContainer: darkMode()
       ? baseColor.darkGray
       : baseColor.highLightGray,
-    $settingRoot: darkMode() ? baseColor.black : baseColor.highLightGray,
-    $settingMenu: darkMode() ? baseColor.darkGray : baseColor.white,
+    $settingRoot: darkMode() ? baseColor.pitchBlack : baseColor.highLightGray,
+    $settingMenu: darkMode() ? baseColor.black : baseColor.white,
     $chip: darkMode() ? baseColor.black : baseColor.highLightGray,
     $chipText: darkMode() ? baseColor.lightGray : baseColor.gray,
     $button: darkMode() ? baseColor.black : baseColor.main,
     $secondaryButton: darkMode() ? baseColor.white : baseColor.main,
     $buttonBorder: darkMode() ? baseColor.white : baseColor.main,
+    $tabTitleActiveColor: darkMode() ? baseColor.white : baseColor.main,
+    $tabTitleColor: darkMode() ? baseColor.lightGray : baseColor.darkGray,
   });
 };
 
@@ -188,3 +219,27 @@ const getTheme = () => {
 };
 
 export default getTheme;
+
+export const NavigationDefaultTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    primary: baseColor.main,
+    text: baseColor.lightGreen,
+    background: baseColor.white,
+    card: baseColor.white,
+    border: baseColor.gray,
+  },
+};
+
+export const NavigationDarkTheme = {
+  ...DarkTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    primary: baseColor.lightGray,
+    text: baseColor.white,
+    background: baseColor.pitchBlack,
+    card: baseColor.pitchBlack,
+    border: baseColor.highLightGray,
+  },
+};

--- a/PeperomiaNative/src/lib/navigation.ts
+++ b/PeperomiaNative/src/lib/navigation.ts
@@ -4,10 +4,6 @@ import { SelectItemDetail } from 'domain/itemDetail';
 
 export const navigationOption = (title: string) => ({
   title,
-  headerTitleStyle: {
-    color: theme().mode.header.text,
-  },
-  headerTintColor: theme().mode.header.text,
   headerStyle: {
     backgroundColor: theme().mode.header.backgroundColor,
   },

--- a/PeperomiaNative/yarn.lock
+++ b/PeperomiaNative/yarn.lock
@@ -17800,14 +17800,7 @@ use-sidecar@^1.0.1:
     detect-node "^2.0.4"
     tslib "^1.9.3"
 
-use-subscription@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.4.0.tgz#c4e808cfed6fe6e1ac875df1369c63f3ddae9522"
-  integrity sha512-R7P7JWpeHp+dtEYsgDzIIgOmVqRfJjRjLOO0YIYk6twctUkUYe6Tz0pcabyTDGcMMRt9uMbFMfwBfxKHg9gCSw==
-  dependencies:
-    object-assign "^4.1.1"
-
-use-subscription@^1.4.0:
+use-subscription@^1.0.0, use-subscription@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.4.1.tgz#edcbcc220f1adb2dd4fa0b2f61b6cc308e620069"
   integrity sha512-7+IIwDG/4JICrWHL/Q/ZPK5yozEnvRm6vHImu0LKwQlmWGKeiF7mbAenLlK/cTNXrTtXHU/SFASQHzB6+oSJMQ==


### PR DESCRIPTION
## 関連 issue
 -  fixes #566

## 対応内容

react-navigation v5のThemesの設定と

https://reactnavigation.org/docs/themes


ExpoのAppearance（機種のモード設定を取得できる）を実装して機種のモードでダークモードON/OFFするように変更

https://docs.expo.io/versions/latest/sdk/appearance

こんな感じになりました

![20200426120605](https://user-images.githubusercontent.com/19209314/84451753-e70ddb80-ac8e-11ea-9520-7179743a8343.gif)

## 開発用メモ
無し