### PR TITLE
バックアップのAPI対応

### DIFF
--- a/src/components/pages/MyPage/__tests__/Connected.test.tsx
+++ b/src/components/pages/MyPage/__tests__/Connected.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
+import * as queries from 'queries/api/index';
 import Connected from '../Connected';
 
 describe('components/pages/MyPage/Connected.tsx', () => {
@@ -24,6 +25,10 @@ describe('components/pages/MyPage/Connected.tsx', () => {
   });
 
   beforeEach(() => {
+    jest
+      .spyOn(queries, 'useSyncCalendarsMutation')
+      .mockImplementation(() => [jest.fn()] as any);
+
     wrapper = shallow(<Connected {...propsData()} />);
   });
 

--- a/src/components/pages/SignIn/__tests__/Connected.test.tsx
+++ b/src/components/pages/SignIn/__tests__/Connected.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
+import * as queries from 'queries/api/index';
 import Connected from '../Connected';
 
 describe('components/pages/SignIn/Connected.tsx', () => {
@@ -24,6 +25,10 @@ describe('components/pages/SignIn/Connected.tsx', () => {
   });
 
   beforeEach(() => {
+    jest
+      .spyOn(queries, 'useSyncCalendarsMutation')
+      .mockImplementation(() => [jest.fn()] as any);
+
     wrapper = shallow(<Connected {...propsData()} />);
   });
 

--- a/src/queries/syncCalendars.gql
+++ b/src/queries/syncCalendars.gql
@@ -1,0 +1,3 @@
+mutation SyncCalendars($calendars: SyncCalendars!) {
+  syncCalendars(calendars: $calendars)
+}


### PR DESCRIPTION
## 関連 issue

- fixes #714 

## 対応内容
 - バックアップAPIとつなぎ込み
 - 新規にユーザー作成した時にSQLiteのデータをFirestoreに挿入する

## 開発用メモ
無し

